### PR TITLE
Removes duplicated autofocus attribute

### DIFF
--- a/src/pages/auth/register.tsx
+++ b/src/pages/auth/register.tsx
@@ -107,7 +107,6 @@ const Register = () => {
             onChange={handleChange}
             placeholder="First Name"
             required
-            autoFocus
           />
           <input
             className="input-field"
@@ -116,7 +115,6 @@ const Register = () => {
             onChange={handleChange}
             placeholder="Last Name"
             required
-            autoFocus
           />
           <PasswordInput
             name="password"


### PR DESCRIPTION
# Description
The autofocus attribute was duplicated across multiple inputs when the last and first name inputs were added to the registration form. This removes the duplicated autofocus attribute so focus will be on the invite code input when the user lands on the registration page.